### PR TITLE
set LLBCaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ This uses Go WebAssembly + BuildKit package.
     <img src="./static/sp.gif" width="80%">
 </p>
 
+## How to develop
+
+```bash
+## build wasm
+make build
+
+## run file server
+make exec
+```
+
 ## Go + WebAssembly
 https://github.com/golang/go/wiki/WebAssembly
 

--- a/docker2dot/docker2dot.go
+++ b/docker2dot/docker2dot.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/imagemetaresolver"
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -16,7 +17,16 @@ import (
 
 // Docker2Dot convert dockerfile to llb Expressed in DOT language.
 func Docker2Dot(df []byte) ([]byte, error) {
-	st, img, err := dockerfile2llb.Dockerfile2LLB(context.Background(), df, dockerfile2llb.ConvertOpt{})
+	caps := pb.Caps.CapSet(pb.Caps.All())
+
+	st, img, err := dockerfile2llb.Dockerfile2LLB(
+		context.Background(),
+		df,
+		dockerfile2llb.ConvertOpt{
+			MetaResolver: imagemetaresolver.Default(),
+			LLBCaps:      &caps,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
close #1 

to generate a graph as it would be run on updated buildkit.

## reference
https://github.com/moby/buildkit/blob/master/examples/dockerfile2llb/main.go#L32